### PR TITLE
Fixed the back button target, pointed to root instead of travel-guide

### DIFF
--- a/src/components/Region.js
+++ b/src/components/Region.js
@@ -20,7 +20,7 @@ const Region = ({ region, countries, search, onSearchChange, flagList }) => {
         <ul className="list">{countryNames}</ul>
         <a
           className="f6 link dim br-pill ph4 pv2 mb2 dib white bg-purple"
-          href="/"
+          href="/travel-guide"
         >
           BACK
         </a>


### PR DESCRIPTION
Simple fix, just pointed the back button to the correct homepage instead of the root of ZtM.