### PR TITLE
corrected README line for npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@
 - Clone(fork) this repository
 - Run these following commands on your terminal/ cmd prompt:
   - cd travel-guide
-  - npm run install
+  - npm install
   - npm run start
   - enter [http://localhost:3000] in your browser


### PR DESCRIPTION
Updated the README file to correct the line regarding npm install. This will install dependencies, whereas the original command looks for an install script that does not exist in the package.json file.

https://github.com/zero-to-mastery/travel-guide/issues/505